### PR TITLE
Lite 14518 structured parameters p1

### DIFF
--- a/lib/connect/api/assetRequests/actions.js
+++ b/lib/connect/api/assetRequests/actions.js
@@ -5,7 +5,12 @@
  */
 
 const { Fulfillment } = require('@cloudblueconnect/connect-javascript-sdk');
-const { filtersToQuery, paramDictToArray, paramErrorDictToArray } = require('../helpers/data');
+const {
+  filtersToQuery,
+  paramDictToArray,
+  paramErrorDictToArray,
+  processStructuredParams,
+} = require('../helpers/data');
 
 
 const FILTERS_MAP = {
@@ -62,7 +67,9 @@ const approveRequest = async (client, data) => {
 
 const updateRequestParameters = async (client, data) => {
   const ff = new Fulfillment(client);
-  const params = Array.isArray(data.params) ? data.params : paramDictToArray(data.params);
+  const params = processStructuredParams(
+    Array.isArray(data.params) ? data.params : paramDictToArray(data.params),
+  );
   const response = await ff.updateRequestParameters(
     data.request_id,
     params,

--- a/lib/connect/api/assetRequests/create.js
+++ b/lib/connect/api/assetRequests/create.js
@@ -7,7 +7,7 @@
 const { Fulfillment } = require('@cloudblueconnect/connect-javascript-sdk');
 const _ = require('lodash');
 
-const { sanitizeItems } = require('../helpers/data');
+const { sanitizeItems, getProductIdFromItems } = require('../helpers/data');
 
 const {
   lookupConnectionByProductHub,
@@ -51,8 +51,7 @@ const needCancelation = (asset, order) => _.every(_.values(_.merge(asset, order)
 const createAssetPurchaseRequest = async (client, inputData) => {
   let req = {};
   const data = _.cloneDeep(inputData);
-  const item = inputData.items[0];
-  const productId = item.item_id.substr(0, 15);
+  const productId = getProductIdFromItems(inputData.items);
   const connectionId = await lookupConnectionByProductHub(client, productId, inputData.hub_id);
   if (!connectionId) {
     throw new Error(`No connection found for product ${productId} and hub ${inputData.hub_id}`);

--- a/lib/connect/api/helpers/builder.js
+++ b/lib/connect/api/helpers/builder.js
@@ -12,6 +12,7 @@ const {
   sanitizeItems,
   itemDictToArray,
   paramDictToArray,
+  processStructuredParams,
 } = require('./data');
 
 const buildTier = (data, t) => {
@@ -54,7 +55,7 @@ const buildPurchaseRequest = (data) => {
         id: data.connection_id,
       },
       items: processItems(data.items),
-      params: paramDictToArray(data.params),
+      params: processStructuredParams(paramDictToArray(data.params)),
       tiers: {
         tier1: buildTier(data, 't1'),
         customer: buildTier(data, 'customer'),

--- a/lib/connect/api/helpers/data.js
+++ b/lib/connect/api/helpers/data.js
@@ -74,6 +74,15 @@ const filtersToQuery = (data, filtersMap) => {
   return queryParams;
 };
 
+const getProductIdFromItems = (items) => {
+  const itemIds = _.keys(items);
+  if (itemIds.length > 0 && itemIds[0].length > 15) {
+    return itemIds[0].substr(0, 15);
+  }
+  return null;
+};
+
+
 module.exports = {
   sanitizeIds,
   sanitizeItems,
@@ -83,4 +92,5 @@ module.exports = {
   filtersToQuery,
   itemDictToArray,
   processStructuredParams,
+  getProductIdFromItems,
 };

--- a/lib/connect/api/helpers/data.js
+++ b/lib/connect/api/helpers/data.js
@@ -39,6 +39,26 @@ const paramErrorDictToArray = (params) => {
   return results;
 };
 
+const processStructuredParams = (params) => {
+  const results = [];
+  _.each(params, (param) => {
+    try {
+      const valueObj = JSON.parse(param.value);
+      if (_.isPlainObject(valueObj)) {
+        results.push({
+          id: param.id,
+          structured_value: valueObj,
+        });
+      } else {
+        results.push(param);
+      }
+    } catch (e) {
+      results.push(param);
+    }
+  });
+  return results;
+};
+
 const filtersToQuery = (data, filtersMap) => {
   const queryParams = {};
   _.forOwn(data, (value, key) => {
@@ -62,4 +82,5 @@ module.exports = {
   paramErrorDictToArray,
   filtersToQuery,
   itemDictToArray,
+  processStructuredParams,
 };

--- a/lib/connect/api/helpers/data.js
+++ b/lib/connect/api/helpers/data.js
@@ -75,9 +75,19 @@ const filtersToQuery = (data, filtersMap) => {
 };
 
 const getProductIdFromItems = (items) => {
-  const itemIds = _.keys(items);
-  if (itemIds.length > 0 && itemIds[0].length > 15) {
-    return itemIds[0].substr(0, 15);
+  if (!Array.isArray(items)) {
+    const itemIds = _.keys(items);
+    if (itemIds.length > 0 && itemIds[0].length > 15) {
+      return itemIds[0].substr(0, 15);
+    }
+    return null;
+  }
+  if (items.length > 0) {
+    const item = items[0];
+    const id = item.item_id ? item.item_id : item.id;
+    if (id && id.length > 15) {
+      return id.substr(0, 15);
+    }
   }
   return null;
 };

--- a/lib/connect/api/tierConfigRequests/actions.js
+++ b/lib/connect/api/tierConfigRequests/actions.js
@@ -5,7 +5,12 @@
  */
 
 const { Fulfillment } = require('@cloudblueconnect/connect-javascript-sdk');
-const { filtersToQuery, paramDictToArray, paramErrorDictToArray } = require('../helpers/data');
+const {
+  filtersToQuery,
+  paramDictToArray,
+  paramErrorDictToArray,
+  processStructuredParams,
+} = require('../helpers/data');
 
 const FILTERS_MAP = {
   type: 'type',
@@ -69,7 +74,9 @@ const failRequest = async (client, data) => {
 };
 
 const updateRequestParameters = async (client, data) => {
-  const params = Array.isArray(data.params) ? data.params : paramDictToArray(data.params);
+  const params = processStructuredParams(
+    Array.isArray(data.params) ? data.params : paramDictToArray(data.params),
+  );
   const ff = new Fulfillment(client);
   const response = await ff.updateTierConfigRequestParameters(
     data.request_id,

--- a/lib/connect/api/tierConfigRequests/create.js
+++ b/lib/connect/api/tierConfigRequests/create.js
@@ -6,11 +6,13 @@
 
 const { Fulfillment } = require('@cloudblueconnect/connect-javascript-sdk');
 
-const { paramDictToArray } = require('../helpers/data');
+const { paramDictToArray, processStructuredParams } = require('../helpers/data');
 
 const createUpdateTierConfigRequest = async (client, data) => {
   const ff = new Fulfillment(client);
-  const params = Array.isArray(data.params) ? data.params : paramDictToArray(data.params);
+  const params = processStructuredParams(
+    Array.isArray(data.params) ? data.params : paramDictToArray(data.params),
+  );
   const response = await ff.createUpdateTierConfigRequest(
     data.config_id,
     params,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "@cloudblueconnect/connect-javascript-sdk": "^20.0.0",
+    "@cloudblueconnect/connect-javascript-sdk": "^20.0.1",
     "google-libphonenumber": "^3.2.6",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-fulfillment-zapier-app",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "description": "A Zapier App to automate Cloud Blue Connect Fulfillment workflows.",
   "repository": {
     "type": "git",

--- a/tests/specs/connect/api/assetRequests/actions.spec.js
+++ b/tests/specs/connect/api/assetRequests/actions.spec.js
@@ -94,11 +94,14 @@ describe('assetRequests.actions', () => {
     };
     const data = {
       request_id: 'PR-000',
-      params: {param_a: 'value_a'},
+      params: {param_a: 'value_a', param_b: '{"a": "value"}'},
       note: 'note'
     };
     await updateRequestParameters(client, data);
-    expect(mockedFn).toHaveBeenCalledWith('PR-000', [{id: 'param_a', value: 'value_a'}], 'note');
+    expect(mockedFn).toHaveBeenCalledWith('PR-000', [
+      {id: 'param_a', value: 'value_a'},
+      {id: 'param_b', structured_value: {a: 'value'}},
+    ], 'note');
   });
   it('updateRequestParameters with param array', async () => {
     const mockedFn = jest.fn();
@@ -107,11 +110,17 @@ describe('assetRequests.actions', () => {
     };
     const data = {
       request_id: 'PR-000',
-      params: [{id: 'param_a', value: 'value_a'}],
+      params: [
+        {id: 'param_a', value: 'value_a'},
+        {id: 'param_b', value: '{"a": "value"}'},
+      ],
       note: 'note'
     };
     await updateRequestParameters(client, data);
-    expect(mockedFn).toHaveBeenCalledWith('PR-000', [{id: 'param_a', value: 'value_a'}], 'note');
+    expect(mockedFn).toHaveBeenCalledWith('PR-000', [
+      {id: 'param_a', value: 'value_a'},
+      {id: 'param_b', structured_value: {a: 'value'}},
+    ], 'note');
   });
   it('inquireRequest with param dict', async () => {
     const mockedFn = jest.fn();

--- a/tests/specs/connect/api/helpers/builder.spec.js
+++ b/tests/specs/connect/api/helpers/builder.spec.js
@@ -147,12 +147,10 @@ describe('helpers.builder', () => {
       { item_id: 'PRD-000-000-000-0001', quantity: 30 },
       { item_id: 'PRD-000-000-000-0002', quantity: 10 },
     ],
-    params: [
-      {
-        param_id: 'param_a',
-        value: 'param_a_value'
-      }
-    ]
+    params: {
+      param_a: 'param_a_value',
+      param_b: '{"a": "hello", "b": "world"}'
+    },
   };
 
   const withT1OnlyNoLineItems = {
@@ -165,12 +163,10 @@ describe('helpers.builder', () => {
       'PRD-000-000-000-0001': 30,
       'PRD-000-000-000-0002': 10,
     },
-    params: [
-      {
-        param_id: 'param_a',
-        value: 'param_a_value'
-      }
-    ]
+    params: {
+      param_a: 'param_a_value',
+      param_b: '{"a": "hello", "b": "world"}',
+    },
   };
 
   const withT1OnlyExpected = {
@@ -183,11 +179,19 @@ describe('helpers.builder', () => {
       items:
         [{ id: 'PRD-000-000-000-0001', quantity: 30 },
         { id: 'PRD-000-000-000-0002', quantity: 10 }],
-      params:
-        [{
-          id: 0,
-          value: { param_id: 'param_a', value: 'param_a_value' }
-        }],
+      params: [
+        { 
+          id: 'param_a', 
+          value: 'param_a_value',
+        },
+        {
+          id: 'param_b',
+          structured_value: {
+            a: 'hello',
+            b: 'world',
+          },
+        },
+      ],
       tiers:
       {
         tier1: t1Out,

--- a/tests/specs/connect/api/helpers/data.spec.js
+++ b/tests/specs/connect/api/helpers/data.spec.js
@@ -13,6 +13,7 @@ const {
   paramErrorDictToArray,
   filtersToQuery,
   processStructuredParams,
+  getProductIdFromItems,
 } = require('../../../../../lib/connect/api/helpers/data');
 
 describe('helpers.data', () => {
@@ -88,6 +89,17 @@ describe('helpers.data', () => {
     ['with null values', filtersNull, filtersNullExpected],
   ])('filtersToQuery map filter names to fields %s', (testcase, data, expected) => {
     expect(filtersToQuery(data, map)).toEqual(expected);
+  });
+  it.each([
+    ['empty array', [], null],
+    ['empty dict', {}, null],
+    ['array ok item_id', [{item_id: 'PRD-000-000-000-0001'}], 'PRD-000-000-000'],
+    ['array ok id', [{id: 'PRD-000-000-000-0001'}], 'PRD-000-000-000'],
+    ['array invalid item', [{item_id: 'PRD-000-0001'}], null],
+    ['dict ok item_id', {'PRD-000-000-000-0001': 33}, 'PRD-000-000-000'],
+    ['dict invalid item', {'invalid': 33}, null],
+  ])('getProductIdFromItems (%s) extract the product id or null', (testcase, data, expected) => {
+    expect(getProductIdFromItems(data)).toEqual(expected);
   });
   it('processStructuredParams convert JSON value to structured_value', () => {
     const params = [

--- a/tests/specs/connect/api/helpers/data.spec.js
+++ b/tests/specs/connect/api/helpers/data.spec.js
@@ -12,6 +12,7 @@ const {
   paramDictToArray,
   paramErrorDictToArray,
   filtersToQuery,
+  processStructuredParams,
 } = require('../../../../../lib/connect/api/helpers/data');
 
 describe('helpers.data', () => {
@@ -87,5 +88,40 @@ describe('helpers.data', () => {
     ['with null values', filtersNull, filtersNullExpected],
   ])('filtersToQuery map filter names to fields %s', (testcase, data, expected) => {
     expect(filtersToQuery(data, map)).toEqual(expected);
+  });
+  it('processStructuredParams convert JSON value to structured_value', () => {
+    const params = [
+      {
+        id: 'p1',
+        value: 'string',
+      },
+      {
+        id: 'p2',
+        value: 33,
+      },
+      {
+        id: 'p3',
+        value: '{"a": "hello", "b": 10, "c": true}',
+      },   
+    ];
+    const expected = [
+      {
+        id: 'p1',
+        value: 'string',
+      },
+      {
+        id: 'p2',
+        value: 33,
+      },
+      {
+        id: 'p3',
+        structured_value: {
+          a: "hello",
+          b: 10,
+          c: true
+        },
+      },    
+    ];
+    expect(processStructuredParams(params)).toEqual(expected);
   });
 });

--- a/tests/specs/connect/api/tierConfigRequests/actions.spec.js
+++ b/tests/specs/connect/api/tierConfigRequests/actions.spec.js
@@ -111,11 +111,14 @@ describe('tierConfigRequests.actions', () => {
     };
     const data = {
       request_id: 'TCR-000',
-      params: {param_a: 'value_a'},
+      params: {param_a: 'value_a', param_b: '{"a": "value"}'},
       notes: 'notes'
     };
     await updateRequestParameters(client, data);
-    expect(mockedFn).toHaveBeenCalledWith('TCR-000', [{id: 'param_a', value: 'value_a'}], 'notes');
+    expect(mockedFn).toHaveBeenCalledWith('TCR-000', [
+      {id: 'param_a', value: 'value_a'},
+      {id: 'param_b', structured_value: {a: 'value'}},
+    ], 'notes');
   });
   it('updateRequestParameters with param array', async () => {
     const mockedFn = jest.fn();
@@ -124,11 +127,17 @@ describe('tierConfigRequests.actions', () => {
     };
     const data = {
       request_id: 'TCR-000',
-      params: [{id: 'param_a', value: 'value_a'}],
+      params: [
+        {id: 'param_a', value: 'value_a'},
+        {id: 'param_b', value: '{"a": "value"}'},
+      ],
       notes: 'notes'
     };
     await updateRequestParameters(client, data);
-    expect(mockedFn).toHaveBeenCalledWith('TCR-000', [{id: 'param_a', value: 'value_a'}], 'notes');
+    expect(mockedFn).toHaveBeenCalledWith('TCR-000', [
+      {id: 'param_a', value: 'value_a'},
+      {id: 'param_b', structured_value: {a: 'value'}},
+    ], 'notes');
   });
   it('inquireRequest with param dict', async () => {
     const mockedFn = jest.fn();

--- a/tests/specs/connect/api/tierConfigRequests/create.spec.js
+++ b/tests/specs/connect/api/tierConfigRequests/create.spec.js
@@ -38,10 +38,14 @@ describe('tierConfigRequests.create', () => {
     await createUpdateTierConfigRequest(client, {
       config_id: 'TC-000',
       params: {
-        param_a: 'value_a'
+        param_a: 'value_a',
+        param_b: '{"a": "value"}',
       }
     });
-    expect(mockedFn).toHaveBeenCalledWith('TC-000', [{ id: 'param_a', value: 'value_a' }]);
+    expect(mockedFn).toHaveBeenCalledWith('TC-000', [
+      { id: 'param_a', value: 'value_a' },
+      { id: 'param_b', structured_value: {a: 'value'} },
+    ]);
   });
   it('createUpdateTierConfigRequest with params array', async () => {
     const mockedFn = jest.fn();
@@ -50,11 +54,20 @@ describe('tierConfigRequests.create', () => {
     };
     await createUpdateTierConfigRequest(client, {
       config_id: 'TC-000',
-      params: [{
-        id: 'param_a',
-        value: 'value_a'
-      }]
+      params: [
+        {
+          id: 'param_a',
+          value: 'value_a',
+        },
+        {
+          id: 'param_b',
+          value: '{"a": "value"}',
+        },
+      ]
     });
-    expect(mockedFn).toHaveBeenCalledWith('TC-000', [{ id: 'param_a', value: 'value_a' }]);
+    expect(mockedFn).toHaveBeenCalledWith('TC-000', [
+      { id: 'param_a', value: 'value_a' },
+      { id: 'param_b', structured_value: {a: 'value'} },
+    ]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,10 +159,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudblueconnect/connect-javascript-sdk@^20.0.0":
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/@cloudblueconnect/connect-javascript-sdk/-/connect-javascript-sdk-20.0.0.tgz#c724e7cd5d30960601870f21f5eb1675fe2d152a"
-  integrity sha512-IRMSoWz2s5JxWH09saoNk8ed1ztyn5KP+yhc5a78xB9d/H0cejChpd7v7QJWKr8zKxiuqhJ3TQ8aPqJP6r361Q==
+"@cloudblueconnect/connect-javascript-sdk@^20.0.1":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@cloudblueconnect/connect-javascript-sdk/-/connect-javascript-sdk-20.0.1.tgz#38330e8186a8e1803fc76dde46c5e82d512b421d"
+  integrity sha512-LVOGoqpQ52we9zZTe1zODEGKaOklkABpxj8cYMIyZH4xFUMxpzF9+BkH9rcPqmNeBbqa6OApYNObAYqo4N/9ZA==
   dependencies:
     node-fetch "^2.6.0"
     ramda "^0.26.1"


### PR DESCRIPTION
Add support for complex (structured_value) parameters for actions:

* Create Asset Purchase Request
* Create Asset Purchase Request (Line Items)
* Fill Fulfillment Parameters
* Fill Fulfillment Parameters (Line Items)
* Create Update Tier Config Request
* Create Update Tier Config Request (Line Items)
* Fill TCR Parameters
* Fill TCR Parameters (Line Items)

Now users can specify the value of a complex parameter as a JSON object.


Fix a bug that breaks asset request creation